### PR TITLE
Skip vlans with no dhcpv6 server configured (#46)

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -44,7 +44,6 @@ jobs:
           libnl-route-3-dev \
           libnl-genl-3-dev \
           libnl-nf-3-dev \
-          libjsoncpp-dev \
           redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
       sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,6 @@ jobs:
             libnl-nf-3-dev \
             libnl-genl-3-dev \
             libgmock-dev \
-            libjsoncpp-dev \
             dh-exec \
             swig3.0 \
             uuid-dev \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MKDIR := mkdir
 MV := mv
 FIND := find
 GCOVR := gcovr
-override LDLIBS += -levent -lhiredis -lswsscommon -pthread -lboost_thread -lboost_system -ljsoncpp
+override LDLIBS += -levent -lhiredis -lswsscommon -pthread -lboost_thread -lboost_system
 override CPPFLAGS += -Wall -std=c++17 -fPIE -I/usr/include/swss
 override CPPFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)"
 CPPFLAGS_TEST := --coverage -fprofile-arcs -ftest-coverage -fprofile-generate -fsanitize=address

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -11,7 +11,6 @@ extraction:
       - "libnl-nf-3-dev"
       - "libnl-genl-3-dev"
       - "libgmock-dev"
-      - "libjsoncpp-dev"
       - "dh-exec"
       - "swig3.0"
       - "uuid-dev"

--- a/src/config_interface.cpp
+++ b/src/config_interface.cpp
@@ -145,6 +145,10 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
                 intf.is_interface_id = true;
             }
         }
+        if (intf.servers.empty()) {
+            syslog(LOG_WARNING, "No servers found for VLAN %s, skipping configuration.", vlan.c_str());
+            continue;
+        }
         syslog(LOG_INFO, "add %s relay config, option79 %s interface-id %s\n", vlan.c_str(),
                intf.is_option_79 ? "enable" : "disable", intf.is_interface_id ? "enable" : "disable");
         vlans[vlan] = intf;

--- a/src/relay.h
+++ b/src/relay.h
@@ -11,10 +11,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <event.h>
-#include <event2/event.h>
 #include <event2/util.h>
-#include <event2/bufferevent.h>
 #include <syslog.h>
 #include "dbconnector.h"
 #include "table.h"
@@ -63,15 +60,6 @@ typedef enum
 
     DHCPv6_MESSAGE_TYPE_COUNT
 } dhcp_message_type_t;
-
-/** packet direction */
-typedef enum
-{
-    DHCPV6_RX,    /** RX DHCPV6 packet */
-    DHCPV6_TX,    /** TX DHCPV6 packet */
-
-    DHCPV6_DIR_COUNT
-} dhcpv6_pkt_dir_t;
 
 struct relay_config {
     int gua_sock; 
@@ -170,15 +158,15 @@ private:
 };
 
 /**
- * @code                prepare_raw_socket(const struct sock_fprog *fprog);
+ * @code                sock_open(const struct sock_fprog *fprog);
  *
- * @brief               prepare raw socket filter 
+ * @brief               prepare L2 socket to attach to "udp and port 547" filter 
  *
- * @param fprog         bpf filter
+ * @param fprog         bpf filter "udp and port 547"
  *
  * @return              socket descriptor
  */
-int prepare_raw_socket(const struct sock_fprog *fprog);
+int sock_open(const struct sock_fprog *fprog);
 
 /**
  * @code                prepare_lo_socket(const char *lo);
@@ -349,20 +337,17 @@ void shutdown_relay();
 void initialize_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname);
 
 /**
- * @code                void increase_counter(swss::DBConnector *state_db, std::string ifname,
- *                                            uint8_t msg_type, dhcpv6_pkt_dir_t dir);
+ * @code                void increase_counter(shared_ptr<swss::DBConnector>, std::string ifname, uint8_t msg_type);
  *
  * @brief               increase the counter in state_db with count of each DHCPv6 message type
  *
  * @param shared_ptr<swss::DBConnector> state_db     state_db connector
  * @param ifname        interface name
  * @param msg_type      dhcpv6 message type to be increased in counter
- * @param dir           dhcpv6 packet direction
  * 
  * @return              none
  */
-void increase_counter(swss::DBConnector *state_db, std::string &ifname,
-                      uint8_t msg_type, dhcpv6_pkt_dir_t dir);
+void increase_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname, uint8_t msg_type);
 
 /* Helper functions */
 
@@ -438,8 +423,7 @@ const struct dhcpv6_msg *parse_dhcpv6_hdr(const uint8_t *buffer);
 const struct dhcpv6_relay_msg *parse_dhcpv6_relay(const uint8_t *buffer);
 
 /**
- * @code                update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb,
- *                                          std::shared_ptr<swss::DBConnector> statdb);
+ * @code                update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb);
  *
  * @brief               build vlan member interface to vlan mapping table 
  *
@@ -448,36 +432,10 @@ const struct dhcpv6_relay_msg *parse_dhcpv6_relay(const uint8_t *buffer);
  *
  * @return              none
  */
-void update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb,
-                         std::shared_ptr<swss::DBConnector> statdb);
+void update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb);
 
 /**
- * @code                update_portchannel_mapping(std::shared_ptr<swss::DBConnector> cfgdb,
- *                                                 std::shared_ptr<swss::DBConnector> statdb);
- *
- * @brief               build portchannel member interface mapping table 
- *
- * @param cfgdb         config db connection
- * @param statdb        state db connection
- *
- * @return              none
- */
-void update_portchannel_mapping(std::shared_ptr<swss::DBConnector> cfgdb, std::shared_ptr<swss::DBConnector> statdb);
-
-/**
- * @code                update_loopback_mapping(std::string &ifname, std::shared_ptr<swss::DBConnector> statdb);
- *
- * @brief               update loopback interface mapping, currently only counter related initialization
- *
- * @param ifname        loopback interface name
- * @param statdb        state db connection
- *
- * @return              none
- */
-void update_loopback_mapping(std::string &ifname, std::shared_ptr<swss::DBConnector> statdb);
-
-/**
- * @code                inbound_callback(evutil_socket_t fd, short event, void *arg);
+ * @code                client_callback(evutil_socket_t fd, short event, void *arg);
  *
  * @brief               callback for libevent that is called everytime data is received at the filter socket
  *
@@ -487,7 +445,7 @@ void update_loopback_mapping(std::string &ifname, std::shared_ptr<swss::DBConnec
  *
  * @return              none
  */
-void inbound_callback(evutil_socket_t fd, short event, void *arg);
+void client_callback(evutil_socket_t fd, short event, void *arg);
 
 /**
  * @code                client_packet_handler(uint8_t *buffer, ssize_t length, struct relay_config *config, std::string &ifname);
@@ -516,56 +474,3 @@ void client_packet_handler(uint8_t *buffer, ssize_t length, struct relay_config 
  */
 void server_callback(evutil_socket_t fd, short event, void *arg);
 
-/**
- * @code                outbound_callback(evutil_socket_t fd, short event, void *arg);
- *
- * @brief               callback for outbound socket, only for counting purpose
- *
- * @param fd            outbound socket
- * @param event         libevent triggered event
- * @param arg           callback argument provided by user
- *
- * @return              none
- */
-void outbound_callback(evutil_socket_t fd, short event, void *arg);
-
-/**
- * @code                packet_counting_handler(uint8_t *buffer, ssize_t length, std::string &ifname,
-                                                swss::DBConnector *state_db, dhcpv6_pkt_dir_t dir);
- *
- * @brief               packet couting handler
- *
- * @param buffer        packet buffer
- * @param length        packet length
- * @param ifname        vlan member interface name
- * @param state_db      state db pointer
- * @param dir           packet direction
- *
- * @return              none
- */
-void packet_counting_handler(uint8_t *buffer, ssize_t length, std::string &ifname,
-                             swss::DBConnector *state_db, dhcpv6_pkt_dir_t rx);
-
-/**
- * @code prepare_socket_callback(event_base *base, int socket,
- *                               void (*cb)(evutil_socket_t, short, void *), void *arg);
- * 
- * @brief Set socket read event callback
- * 
- * @param base        libevent base
- * @param socket      target socket
- * @param cb          callback function
- * @param arg         callback function argument
- * 
- */
-void prepare_socket_callback(event_base *base, int socket, void (*cb)(evutil_socket_t, short, void *), void *arg);
-
-/**
- * @code clear_counter(std::shared_ptr<swss::DBConnector> state_db);
- * 
- * @brief Clear all counter
- * 
- * @param state_db      state_db connector pointer
- * 
- */
-void clear_counter(std::shared_ptr<swss::DBConnector> state_db);


### PR DESCRIPTION
**Why I did it**
When not all vlans have dhcpv6 servers configured, dhcp6relay fails to start because it expects all vlans under DHCP_RELAY table to have dhcpv6 server configured.

**Work item tracking**

- Microsoft ADO (number only):

**How I did it**
Skip adding vlan to dhcp6relay if no dhcpv6 servers are configured

**How to verify it**
Tested by configuring DHCP_RELAY|Vlan200 to NULL values and configuring dhcpv6 servers for DHCP_RELAY|Vlan100. Dhcp6relay will only open sockets for Vlan100 and not Vlan200