### PR TITLE
Skip vlans with no dhcpv6 server configured (#46)

### DIFF
--- a/src/config_interface.cpp
+++ b/src/config_interface.cpp
@@ -145,6 +145,10 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
                 intf.is_interface_id = true;
             }
         }
+        if (intf.servers.empty()) {
+            syslog(LOG_WARNING, "No servers found for VLAN %s, skipping configuration.", vlan.c_str());
+            continue;
+        }
         syslog(LOG_INFO, "add %s relay config, option79 %s interface-id %s\n", vlan.c_str(),
                intf.is_option_79 ? "enable" : "disable", intf.is_interface_id ? "enable" : "disable");
         vlans[vlan] = intf;


### PR DESCRIPTION
**Why I did it**
When not all vlans have dhcpv6 servers configured, dhcp6relay fails to start because it expects all vlans under DHCP_RELAY table to have dhcpv6 server configured.

**Work item tracking**

- Microsoft ADO (number only):

**How I did it**
Skip adding vlan to dhcp6relay if no dhcpv6 servers are configured

**How to verify it**
Tested by configuring DHCP_RELAY|Vlan200 to NULL values and configuring dhcpv6 servers for DHCP_RELAY|Vlan100. Dhcp6relay will only open sockets for Vlan100 and not Vlan200