### PR TITLE
Revert DHCPv6 Counter (#48)

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -44,7 +44,6 @@ jobs:
           libnl-route-3-dev \
           libnl-genl-3-dev \
           libnl-nf-3-dev \
-          libjsoncpp-dev \
           redis-server
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
       sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,6 @@ jobs:
             libnl-nf-3-dev \
             libnl-genl-3-dev \
             libgmock-dev \
-            libjsoncpp-dev \
             dh-exec \
             swig3.0 \
             uuid-dev \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MKDIR := mkdir
 MV := mv
 FIND := find
 GCOVR := gcovr
-override LDLIBS += -levent -lhiredis -lswsscommon -pthread -lboost_thread -lboost_system -ljsoncpp
+override LDLIBS += -levent -lhiredis -lswsscommon -pthread -lboost_thread -lboost_system
 override CPPFLAGS += -Wall -std=c++17 -fPIE -I/usr/include/swss
 override CPPFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)"
 CPPFLAGS_TEST := --coverage -fprofile-arcs -ftest-coverage -fprofile-generate -fsanitize=address

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -11,7 +11,6 @@ extraction:
       - "libnl-nf-3-dev"
       - "libnl-genl-3-dev"
       - "libgmock-dev"
-      - "libjsoncpp-dev"
       - "dh-exec"
       - "swig3.0"
       - "uuid-dev"

--- a/src/relay.h
+++ b/src/relay.h
@@ -11,10 +11,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <event.h>
-#include <event2/event.h>
 #include <event2/util.h>
-#include <event2/bufferevent.h>
 #include <syslog.h>
 #include "dbconnector.h"
 #include "table.h"
@@ -63,15 +60,6 @@ typedef enum
 
     DHCPv6_MESSAGE_TYPE_COUNT
 } dhcp_message_type_t;
-
-/** packet direction */
-typedef enum
-{
-    DHCPV6_RX,    /** RX DHCPV6 packet */
-    DHCPV6_TX,    /** TX DHCPV6 packet */
-
-    DHCPV6_DIR_COUNT
-} dhcpv6_pkt_dir_t;
 
 struct relay_config {
     int gua_sock; 
@@ -170,15 +158,15 @@ private:
 };
 
 /**
- * @code                prepare_raw_socket(const struct sock_fprog *fprog);
+ * @code                sock_open(const struct sock_fprog *fprog);
  *
- * @brief               prepare raw socket filter 
+ * @brief               prepare L2 socket to attach to "udp and port 547" filter 
  *
- * @param fprog         bpf filter
+ * @param fprog         bpf filter "udp and port 547"
  *
  * @return              socket descriptor
  */
-int prepare_raw_socket(const struct sock_fprog *fprog);
+int sock_open(const struct sock_fprog *fprog);
 
 /**
  * @code                prepare_lo_socket(const char *lo);
@@ -349,20 +337,17 @@ void shutdown_relay();
 void initialize_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname);
 
 /**
- * @code                void increase_counter(swss::DBConnector *state_db, std::string ifname,
- *                                            uint8_t msg_type, dhcpv6_pkt_dir_t dir);
+ * @code                void increase_counter(shared_ptr<swss::DBConnector>, std::string ifname, uint8_t msg_type);
  *
  * @brief               increase the counter in state_db with count of each DHCPv6 message type
  *
  * @param shared_ptr<swss::DBConnector> state_db     state_db connector
  * @param ifname        interface name
  * @param msg_type      dhcpv6 message type to be increased in counter
- * @param dir           dhcpv6 packet direction
  * 
  * @return              none
  */
-void increase_counter(swss::DBConnector *state_db, std::string &ifname,
-                      uint8_t msg_type, dhcpv6_pkt_dir_t dir);
+void increase_counter(std::shared_ptr<swss::DBConnector> state_db, std::string &ifname, uint8_t msg_type);
 
 /* Helper functions */
 
@@ -438,8 +423,7 @@ const struct dhcpv6_msg *parse_dhcpv6_hdr(const uint8_t *buffer);
 const struct dhcpv6_relay_msg *parse_dhcpv6_relay(const uint8_t *buffer);
 
 /**
- * @code                update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb,
- *                                          std::shared_ptr<swss::DBConnector> statdb);
+ * @code                update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb);
  *
  * @brief               build vlan member interface to vlan mapping table 
  *
@@ -448,36 +432,10 @@ const struct dhcpv6_relay_msg *parse_dhcpv6_relay(const uint8_t *buffer);
  *
  * @return              none
  */
-void update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb,
-                         std::shared_ptr<swss::DBConnector> statdb);
+void update_vlan_mapping(std::string vlan, std::shared_ptr<swss::DBConnector> cfgdb);
 
 /**
- * @code                update_portchannel_mapping(std::shared_ptr<swss::DBConnector> cfgdb,
- *                                                 std::shared_ptr<swss::DBConnector> statdb);
- *
- * @brief               build portchannel member interface mapping table 
- *
- * @param cfgdb         config db connection
- * @param statdb        state db connection
- *
- * @return              none
- */
-void update_portchannel_mapping(std::shared_ptr<swss::DBConnector> cfgdb, std::shared_ptr<swss::DBConnector> statdb);
-
-/**
- * @code                update_loopback_mapping(std::string &ifname, std::shared_ptr<swss::DBConnector> statdb);
- *
- * @brief               update loopback interface mapping, currently only counter related initialization
- *
- * @param ifname        loopback interface name
- * @param statdb        state db connection
- *
- * @return              none
- */
-void update_loopback_mapping(std::string &ifname, std::shared_ptr<swss::DBConnector> statdb);
-
-/**
- * @code                inbound_callback(evutil_socket_t fd, short event, void *arg);
+ * @code                client_callback(evutil_socket_t fd, short event, void *arg);
  *
  * @brief               callback for libevent that is called everytime data is received at the filter socket
  *
@@ -487,7 +445,7 @@ void update_loopback_mapping(std::string &ifname, std::shared_ptr<swss::DBConnec
  *
  * @return              none
  */
-void inbound_callback(evutil_socket_t fd, short event, void *arg);
+void client_callback(evutil_socket_t fd, short event, void *arg);
 
 /**
  * @code                client_packet_handler(uint8_t *buffer, ssize_t length, struct relay_config *config, std::string &ifname);
@@ -516,56 +474,3 @@ void client_packet_handler(uint8_t *buffer, ssize_t length, struct relay_config 
  */
 void server_callback(evutil_socket_t fd, short event, void *arg);
 
-/**
- * @code                outbound_callback(evutil_socket_t fd, short event, void *arg);
- *
- * @brief               callback for outbound socket, only for counting purpose
- *
- * @param fd            outbound socket
- * @param event         libevent triggered event
- * @param arg           callback argument provided by user
- *
- * @return              none
- */
-void outbound_callback(evutil_socket_t fd, short event, void *arg);
-
-/**
- * @code                packet_counting_handler(uint8_t *buffer, ssize_t length, std::string &ifname,
-                                                swss::DBConnector *state_db, dhcpv6_pkt_dir_t dir);
- *
- * @brief               packet couting handler
- *
- * @param buffer        packet buffer
- * @param length        packet length
- * @param ifname        vlan member interface name
- * @param state_db      state db pointer
- * @param dir           packet direction
- *
- * @return              none
- */
-void packet_counting_handler(uint8_t *buffer, ssize_t length, std::string &ifname,
-                             swss::DBConnector *state_db, dhcpv6_pkt_dir_t rx);
-
-/**
- * @code prepare_socket_callback(event_base *base, int socket,
- *                               void (*cb)(evutil_socket_t, short, void *), void *arg);
- * 
- * @brief Set socket read event callback
- * 
- * @param base        libevent base
- * @param socket      target socket
- * @param cb          callback function
- * @param arg         callback function argument
- * 
- */
-void prepare_socket_callback(event_base *base, int socket, void (*cb)(evutil_socket_t, short, void *), void *arg);
-
-/**
- * @code clear_counter(std::shared_ptr<swss::DBConnector> state_db);
- * 
- * @brief Clear all counter
- * 
- * @param state_db      state_db connector pointer
- * 
- */
-void clear_counter(std::shared_ptr<swss::DBConnector> state_db);


### PR DESCRIPTION
* Revert "[counter] Clear counter table when init (#45)"

This reverts commit 5ae186f4a6c25647f5ce7b4d2c884b08423455e7.

* Revert "dhcpv6 per interface counter support (#43)"

This reverts commit 2b33d76dbac69d3d9ad9e9f2d37252db525f07b9.

* Update buster to bullseye libyang deb